### PR TITLE
This PR fix a bug when using custom rule set file

### DIFF
--- a/CenterCLR.RelaxVersioner/Utilities.cs
+++ b/CenterCLR.RelaxVersioner/Utilities.cs
@@ -169,7 +169,7 @@ namespace CenterCLR.RelaxVersioner
                     StringComparer.InvariantCultureIgnoreCase).
                 ToDictionary(
                     g => g.Key,
-                    g => from rule in g.Elements("Rule")
+                    g => from rule in g.First().Elements("Rule")
                         let name = rule.Attribute("name")
                         let key = rule.Attribute("key")
                         where !string.IsNullOrWhiteSpace(name?.Value)


### PR DESCRIPTION
Fix a bug when using custom rule set file.
I am changing to adopt the first found rule set.
For details of the bug, please see the following.
---
 Using a custom ruleset file always results in an error.

- [Compiler Error CS0579 - Duplicate 'attribute' attribute](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0579)  
  
This is because AssemblyInfo.cs contains not only the contents of the custom rule set file but also the default rule set.  
Below is the contents of RelaxVersioner.rules and the generated AssemblyInfo.cs.

#### Contents of created RelaxVersioner.rules
```RelaxVersioner.rules  
<?xml version="1.0" encoding="utf-8"?>
<RelaxVersioner version="1.0">
    <WriterRules>
        <!-- Target languages -->
        <Language>C#</Language>
        <Language>F#</Language>
        <Language>VB</Language>
        <Language>C++/CLI</Language>
        <!--
            "gitLabel" is extract numerical-notate version string [1.2.3.4] from git repository tags/branches traverse start HEAD.
            If not found, fallback to "safeVersion".
        -->
        <Rule name="System.Reflection.AssemblyVersionAttribute">1.0.0</Rule>
        <!--
            "safeVersion" is extract committed date (with commmiter) from git repository HEAD.
            "safeVersion" specialized from "committer.When".
            (The format is safe-numerical-notate version string [2016.2.14.12345]. (Last number is 2sec prec.))
        -->
        <!--
            "commitId" is extract commit id from git repository HEAD.
            "commitId" alias to "commit.Sha".
        -->
        <Rule name="System.Reflection.AssemblyInformationalVersionAttribute">1.0.0</Rule>
        <!--
            "key" is only used "AssemblyVersionMetadataAttribute".
            "committer.When" or you can use another choice "author.When".
            "author" and "committer" can use property "Name", "Email", and "When". (Derived from libgit2sharp)
        -->
        <Rule name="System.Reflection.AssemblyVersionMetadataAttribute" key="Build">{committer.When:R}</Rule>
        <Rule name="System.Reflection.AssemblyVersionMetadataAttribute" key="Branch">{branch.Name}</Rule>
        <Rule name="System.Reflection.AssemblyVersionMetadataAttribute" key="Tags">{tags}</Rule>
        <Rule name="System.Reflection.AssemblyVersionMetadataAttribute" key="Author">{author}</Rule>
        <Rule name="System.Reflection.AssemblyVersionMetadataAttribute" key="Committer">{committer}</Rule>
        <Rule name="System.Reflection.AssemblyVersionMetadataAttribute" key="Message">{commit.MessageShort}</Rule>
    </WriterRules>
</RelaxVersioner>
```
  
#### Contents of generated AsemblyInfo.cs
```AssemblyInfo.cs
// This is auto-generated version information attributes by CenterCLR.RelaxVersioner.0.8.11.0
// Do not edit.
// Generated date: Thu, 14 Sep 2017 06:13:20 GMT

[assembly: System.Reflection.AssemblyVersionAttribute(@"1.0.0")]
[assembly: System.Reflection.AssemblyInformationalVersionAttribute(@"1.0.0")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Build",@"Sun, 10 Sep 2017 07:09:03 GMT")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Branch",@"master")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Tags",@"")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Author",@"zizi4n5 <xxxxxxx>")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Committer",@"zizi4n5 <xxxxxxx>")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Message",@"プロジェクト ファイルを追加します。")]
[assembly: System.Reflection.AssemblyVersionAttribute(@"0.0.1.0")]
[assembly: System.Reflection.AssemblyFileVersionAttribute(@"2017.9.10.29071")]
[assembly: System.Reflection.AssemblyInformationalVersionAttribute(@"511ccc9181223ee69014d67473aba102df4231b4")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Build",@"Sun, 10 Sep 2017 07:09:03 GMT")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Branch",@"master")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Tags",@"")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Author",@"zizi4n5 <xxxxxxx>")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Committer",@"zizi4n5 <xxxxxxx>")]
[assembly: System.Reflection.AssemblyVersionMetadataAttribute(@"Message",@"プロジェクト ファイルを追加します。")]

namespace System.Reflection
{
	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
	internal sealed class AssemblyVersionMetadataAttribute : Attribute
	{
		public AssemblyVersionMetadataAttribute(string key, string value)
		{
			this.Key = key;
			this.Value = value;
		}
		public string Key { get; private set; }
		public string Value { get; private set; }
	}
}
```

