### PR TITLE
Add Import Functionality

### DIFF
--- a/CenterCLR.RelaxVersioner/Program.cs
+++ b/CenterCLR.RelaxVersioner/Program.cs
@@ -41,12 +41,14 @@ namespace CenterCLR.RelaxVersioner
                 var writers = Utilities.GetWriters();
                 var writer = writers[language];
 
-                var ruleSets = Utilities.AggregateRuleSets(
+                var elementSets = Utilities.GetElementSets(
                     Utilities.LoadRuleSet(projectDirectory),
                     Utilities.LoadRuleSet(solutionDirectory),
                     Utilities.GetDefaultRuleSet());
 
-                var ruleSet = ruleSets[language].ToList();
+                var elementSet = elementSets[language];
+                var importSet = Utilities.AggregateImports(elementSet);
+                var ruleSet = Utilities.AggregateRules(elementSet);
 
                 // Traverse git repository between projectDirectory and the root.
                 // Why use projectDirectory instead solutionDirectory ?
@@ -83,7 +85,8 @@ namespace CenterCLR.RelaxVersioner
                         tags,
                         branches,
                         DateTimeOffset.Now,
-                        ruleSet);
+                        ruleSet,
+                        importSet);
 
                     Console.WriteLine("RelaxVersioner: Generated versions code: Language={0}, Version={1}", language, gitLabel);
                 }

--- a/CenterCLR.RelaxVersioner/Utilities.cs
+++ b/CenterCLR.RelaxVersioner/Utilities.cs
@@ -151,8 +151,7 @@ namespace CenterCLR.RelaxVersioner
             }
         }
 
-        public static Dictionary<string, IEnumerable<Rule>> AggregateRuleSets(
-            params XElement[] ruleSets)
+        public static Dictionary<string, XElement> GetElementSets(params XElement[] ruleSets)
         {
             Debug.Assert(ruleSets != null);
 
@@ -169,12 +168,23 @@ namespace CenterCLR.RelaxVersioner
                     StringComparer.InvariantCultureIgnoreCase).
                 ToDictionary(
                     g => g.Key,
-                    g => from rule in g.Elements("Rule")
-                        let name = rule.Attribute("name")
-                        let key = rule.Attribute("key")
-                        where !string.IsNullOrWhiteSpace(name?.Value)
-                        select new Rule(name.Value.Trim(), key?.Value.Trim(), rule.Value.Trim()),
+                    g => g.First(),
                     StringComparer.InvariantCultureIgnoreCase);
+        }
+
+        public static IEnumerable<string> AggregateImports(XElement wrules)
+        {
+            return (from import in wrules.Elements("Import")
+                    select import.Value.Trim());
+        }
+
+        public static IEnumerable<Rule> AggregateRules(XElement wrules)
+        {
+            return (from rule in wrules.Elements("Rule")
+                    let name = rule.Attribute("name")
+                    let key = rule.Attribute("key")
+                    where !string.IsNullOrWhiteSpace(name?.Value)
+                    select new Rule(name.Value.Trim(), key?.Value.Trim(), rule.Value.Trim()));
         }
 
         public static IEnumerable<string> AggregateNamespacesFromRuleSet(

--- a/CenterCLR.RelaxVersioner/Writers/CPlusPlusCLIWriter.cs
+++ b/CenterCLR.RelaxVersioner/Writers/CPlusPlusCLIWriter.cs
@@ -51,6 +51,11 @@ namespace CenterCLR.RelaxVersioner.Writers
             tw.WriteLine();
         }
 
+        protected override void WriteImport(TextWriter tw, string namespaceName)
+        {
+            tw.WriteLine("using namespace {0};");
+        }
+        
         protected override string GetArgumentString(string argumentValue)
         {
             return string.Format("\"{0}\"", argumentValue.Replace("\\", "\\\\").Replace("\"", "\\\""));

--- a/CenterCLR.RelaxVersioner/Writers/CPlusPlusCLIWriter.cs
+++ b/CenterCLR.RelaxVersioner/Writers/CPlusPlusCLIWriter.cs
@@ -53,7 +53,7 @@ namespace CenterCLR.RelaxVersioner.Writers
 
         protected override void WriteImport(TextWriter tw, string namespaceName)
         {
-            tw.WriteLine("using namespace {0};");
+            tw.WriteLine("using namespace {0};", namespaceName.Replace(".", "::"));
         }
         
         protected override string GetArgumentString(string argumentValue)

--- a/CenterCLR.RelaxVersioner/Writers/CSharpWriter.cs
+++ b/CenterCLR.RelaxVersioner/Writers/CSharpWriter.cs
@@ -26,6 +26,11 @@ namespace CenterCLR.RelaxVersioner.Writers
     {
         public override string Language => "C#";
 
+        protected override void WriteImport(TextWriter tw, string namespaceName)
+        {
+            tw.WriteLine("using {0};", namespaceName);
+        }
+        
         protected override string GetArgumentString(string argumentValue)
         {
             return string.Format("@\"{0}\"", argumentValue.Replace("\"", "\"\""));

--- a/CenterCLR.RelaxVersioner/Writers/FSharpWriter.cs
+++ b/CenterCLR.RelaxVersioner/Writers/FSharpWriter.cs
@@ -44,6 +44,11 @@ namespace CenterCLR.RelaxVersioner.Writers
             tw.WriteLine();
         }
 
+        protected override void WriteImport(TextWriter tw, string namespaceName)
+        {
+            tw.WriteLine("open {0}", namespaceName);
+        }
+        
         protected override string GetArgumentString(string argumentValue)
         {
             return string.Format("@\"{0}\"", argumentValue.Replace("\"", "\"\""));

--- a/CenterCLR.RelaxVersioner/Writers/FSharpWriter.cs
+++ b/CenterCLR.RelaxVersioner/Writers/FSharpWriter.cs
@@ -46,7 +46,7 @@ namespace CenterCLR.RelaxVersioner.Writers
 
         protected override void WriteImport(TextWriter tw, string namespaceName)
         {
-            tw.WriteLine("open {0}", namespaceName);
+            // tw.WriteLine("open {0}", namespaceName);
         }
         
         protected override string GetArgumentString(string argumentValue)

--- a/CenterCLR.RelaxVersioner/Writers/WriterBase.cs
+++ b/CenterCLR.RelaxVersioner/Writers/WriterBase.cs
@@ -38,7 +38,8 @@ namespace CenterCLR.RelaxVersioner.Writers
             Dictionary<string, IEnumerable<Tag>> tags,
             Dictionary<string, IEnumerable<Branch>> branches,
             DateTimeOffset generated,
-            ICollection<Rule> ruleSet)
+            IEnumerable<Rule> ruleSet,
+            IEnumerable<string> importSet)
         {
             Debug.Assert(string.IsNullOrWhiteSpace(targetPath) == false);
             Debug.Assert(tags != null);
@@ -74,8 +75,7 @@ namespace CenterCLR.RelaxVersioner.Writers
 
                 this.WriteBeforeBody(tw);
 
-                var namespaces = Utilities.AggregateNamespacesFromRuleSet(ruleSet);
-                foreach (var namespaceName in namespaces)
+                foreach (var namespaceName in importSet)
                 {
                     this.WriteImport(tw, namespaceName);
                 }

--- a/TestProjects/CPlusPlusTestProject/RelaxVersioner.rules
+++ b/TestProjects/CPlusPlusTestProject/RelaxVersioner.rules
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+    CenterCLR.RelaxVersioner - Easy-usage, Git-based, auto-generate version informations toolset.
+    Copyright (c) 2016 Kouji Matsui (@kekyo2)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!--
+    This is sample of RelaxVersioner overridable rule sets.
+    Sample contains default rule sets below.
+    You can place custom version rule set file naming "RelaxVersioner.rules" into $(SolutionDir) or $(ProjectDir).
+    RelaxVersioner use files fallback with priority first $(ProjectDir), second $(SolutionDir), and default rule sets.
+-->
+<RelaxVersioner version="1.0">
+    <WriterRules>
+        <Language>VB</Language>
+        <Language>C++/CLI</Language>
+
+        <!-- Namespaces to be imported -->
+        <Import>System.Reflection</Import>
+        <Import>System.Runtime.InteropServices</Import>
+
+        <Rule name="AssemblyVersionAttribute">{gitLabel}</Rule>
+        <Rule name="AssemblyFileVersionAttribute">{safeVersion}</Rule>
+        <Rule name="AssemblyInformationalVersionAttribute">{commitId}</Rule>
+
+        <Rule name="AssemblyVersionMetadataAttribute" key="Build">{committer.When:R}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Branch">{branch.Name}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Tags">{tags}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Author">{author}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Committer">{committer}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Message">{commit.MessageShort}</Rule>
+    </WriterRules>
+    <WriterRules>
+        <!-- Target languages -->
+        <Language>Wix</Language>
+
+        <Rule name="VERSION">{gitLabel}</Rule>
+        <Rule name="DESCRIPTION">{gitLabel}</Rule>
+    </WriterRules>
+</RelaxVersioner>

--- a/TestProjects/CSharpTestProject/RelaxVersioner.rules
+++ b/TestProjects/CSharpTestProject/RelaxVersioner.rules
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+    CenterCLR.RelaxVersioner - Easy-usage, Git-based, auto-generate version informations toolset.
+    Copyright (c) 2016 Kouji Matsui (@kekyo2)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!--
+    This is sample of RelaxVersioner overridable rule sets.
+    Sample contains default rule sets below.
+    You can place custom version rule set file naming "RelaxVersioner.rules" into $(SolutionDir) or $(ProjectDir).
+    RelaxVersioner use files fallback with priority first $(ProjectDir), second $(SolutionDir), and default rule sets.
+-->
+<RelaxVersioner version="1.0">
+    <WriterRules>
+        <!-- Should load the default rule set since the language isn't here -->
+        <Language>F#</Language>
+        <Language>C++/CLI</Language>
+
+        <!-- Namespaces to be imported -->
+        <Import>System.Reflection</Import>
+        <Import>System.Runtime.InteropServices</Import>
+
+        <Rule name="AssemblyVersionAttribute">{gitLabel}</Rule>
+        <Rule name="AssemblyFileVersionAttribute">{safeVersion}</Rule>
+        <Rule name="AssemblyInformationalVersionAttribute">{commitId}</Rule>
+
+        <Rule name="AssemblyVersionMetadataAttribute" key="Build">{committer.When:R}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Branch">{branch.Name}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Tags">{tags}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Author">{author}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Committer">{committer}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Message">{commit.MessageShort}</Rule>
+    </WriterRules>
+    <WriterRules>
+        <!-- Target languages -->
+        <Language>Wix</Language>
+
+        <Rule name="VERSION">{gitLabel}</Rule>
+        <Rule name="DESCRIPTION">{gitLabel}</Rule>
+    </WriterRules>
+</RelaxVersioner>

--- a/TestProjects/VisualBasicTestProject/RelaxVersioner.rules
+++ b/TestProjects/VisualBasicTestProject/RelaxVersioner.rules
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+    CenterCLR.RelaxVersioner - Easy-usage, Git-based, auto-generate version informations toolset.
+    Copyright (c) 2016 Kouji Matsui (@kekyo2)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!--
+    This is sample of RelaxVersioner overridable rule sets.
+    Sample contains default rule sets below.
+    You can place custom version rule set file naming "RelaxVersioner.rules" into $(SolutionDir) or $(ProjectDir).
+    RelaxVersioner use files fallback with priority first $(ProjectDir), second $(SolutionDir), and default rule sets.
+-->
+<RelaxVersioner version="1.0">
+    <WriterRules>
+        <Language>VB</Language>
+        <Language>C++/CLI</Language>
+
+        <!-- Namespaces to be imported -->
+        <Import>System.Reflection</Import>
+        <Import>System.Runtime.InteropServices</Import>
+
+        <Rule name="AssemblyVersionAttribute">{gitLabel}</Rule>
+        <Rule name="AssemblyFileVersionAttribute">{safeVersion}</Rule>
+        <Rule name="AssemblyInformationalVersionAttribute">{commitId}</Rule>
+
+        <Rule name="AssemblyVersionMetadataAttribute" key="Build">{committer.When:R}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Branch">{branch.Name}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Tags">{tags}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Author">{author}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Committer">{committer}</Rule>
+        <Rule name="AssemblyVersionMetadataAttribute" key="Message">{commit.MessageShort}</Rule>
+    </WriterRules>
+    <WriterRules>
+        <!-- Target languages -->
+        <Language>Wix</Language>
+
+        <Rule name="VERSION">{gitLabel}</Rule>
+        <Rule name="DESCRIPTION">{gitLabel}</Rule>
+    </WriterRules>
+</RelaxVersioner>


### PR DESCRIPTION
I added a new kind of WriterRule element that can be put into the `.rules` configuration file.
It's called `Import` and it lets you import namespaces into the assembily attributes file so that you don't have to type `System.Reflection` for every single rule name. Build the solution to get an idea of what I'm talking about.

Unfortunately, I wasn't able to get this to work on F#, as I can't seem to put the code anywhere without getting an error of some kind. I'm not familiar with F# or functional languages in general, so maybe there's a way around it.